### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://bitkit.visualstudio.com/afbbdaf7-ae1e-45cb-816e-99f89b044a1b/a46180f0-b9bd-469b-aecc-57a3bc181c3c/_apis/work/boardbadge/412983e1-ebb4-44e6-9efa-d1c846ff2ba2)](https://bitkit.visualstudio.com/afbbdaf7-ae1e-45cb-816e-99f89b044a1b/_boards/board/t/a46180f0-b9bd-469b-aecc-57a3bc181c3c/Microsoft.RequirementCategory)
 # Heroes_of_Might_and_Magic_3_JSON
 Heroes of Might and Magic 3 - JSON file
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#108](https://bitkit.visualstudio.com/afbbdaf7-ae1e-45cb-816e-99f89b044a1b/_workitems/edit/108). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.